### PR TITLE
Moved AddToShelfForm component to be called inside of ShelfPage

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -21,7 +21,6 @@ import LoginPage from '../LoginPage/LoginPage';
 import RegisterPage from '../RegisterPage/RegisterPage';
 
 import './App.css';
-import AddToShelfForm from '../AddToShelfForm/AddToShelfForm';
 
 function App() {
   const dispatch = useDispatch();
@@ -109,13 +108,6 @@ function App() {
               // Otherwise, show the Landing page
               <LandingPage />
             }
-          </Route>
-
-          <Route
-            exact
-            path="/add-to-shelf"
-          >
-            <AddToShelfForm />
           </Route>
 
           {/* If none of the other routes matched, we will show a 404. */}

--- a/src/components/ShelfPage/AddToShelfForm/AddToShelfForm.css
+++ b/src/components/ShelfPage/AddToShelfForm/AddToShelfForm.css
@@ -1,0 +1,8 @@
+.box {
+  width: 20%;
+  /* background-color: rgb(189, 189, 189); */
+  border: solid black 1px;
+  display: grid;
+  justify-content: center;
+  padding: 1%;
+}

--- a/src/components/ShelfPage/AddToShelfForm/AddToShelfForm.jsx
+++ b/src/components/ShelfPage/AddToShelfForm/AddToShelfForm.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import TextareaAutosize from '@mui/base/TextareaAutosize';
 import TextField from '@mui/material/TextField';
+import './AddToShelfForm.css'
 
 export default function AddToShelfForm () {
 
@@ -129,8 +130,8 @@ export default function AddToShelfForm () {
   } // End descriptionInput
 
   return (
-    <>
-      <h1>Inside Add To Shelf Form</h1>
+    <div className="box">
+      <h3>Add an item to the shelf</h3>
       <form>
         <label>Link to image:</label>
         {imageInput()}
@@ -140,7 +141,6 @@ export default function AddToShelfForm () {
         <br />
         <button onClick={addItemToShelf}>Add Item</button>
       </form>
-
-    </>
+    </div>
   )
 }

--- a/src/components/ShelfPage/ShelfPage.js
+++ b/src/components/ShelfPage/ShelfPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import AddToShelfForm from './AddToShelfForm/AddToShelfForm';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
@@ -26,6 +27,7 @@ useEffect(() => {
   return (
     <div className="container">
       <h2>Shelf</h2>
+      <AddToShelfForm />
       <p>All of the available items can be seen here.</p>
 
       {


### PR DESCRIPTION
- Removed from App.jsx
- AddToShelfForm no longer has it's own http address
- Added styling to AddToShelfForm so it is clear that it's a form within the page and all contained within the border of it's box.